### PR TITLE
Introduce Auth commnad & Fix many problems with publish and install 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+LANG_PATH := $(APP_DATA)/ppm/languages
+
+.PHONY: build
+
+build:
+	mkdir -p "$(LANG_PATH)"
+	cp -r languages/* "$(LANG_PATH)"

--- a/package.bas
+++ b/package.bas
@@ -1,5 +1,5 @@
 Attribute VB_Name = "package"
-'@Folder("PearPMProject")
+'@Folder "PearPMProject"
 '{
 '  "name": "PearPM",
 '  "version": "1.0.0",

--- a/package.bas
+++ b/package.bas
@@ -1,5 +1,5 @@
 Attribute VB_Name = "package"
-'@Folder("PearPMProject")
+'@Folder "PearPMProject"
 '{
 '  "name": "PearPM",
 '  "version": "0.10.0",

--- a/package.bas
+++ b/package.bas
@@ -1,8 +1,8 @@
 Attribute VB_Name = "package"
-'@Folder "PearPMProject"
+'@Folder("PearPMProject")
 '{
 '  "name": "PearPM",
-'  "version": "0.10.0",
+'  "version": "1.0.0",
 '  "description": "ppm is a package manager developed for VBA and with VBA.",
 '  "author": "artemdorozhkin",
 '  "git": "https://github.com/artemdorozhkin/ppm",

--- a/src/CLI/CLI.bas
+++ b/src/CLI/CLI.bas
@@ -14,6 +14,7 @@ End Property
 
 Public Property Get Commands() As Variant
     Commands = Array( _
+        "auth", _
         "class", _
         "config", _
         "export", _

--- a/src/CLI/Commands/Auth/AuthCommand.cls
+++ b/src/CLI/Commands/Auth/AuthCommand.cls
@@ -1,0 +1,91 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "AuthCommand"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = False
+'@Folder "PearPMProject.src.CLI.Commands.Auth"
+Option Explicit
+
+Implements ICommand
+
+Private Type TExportCommand
+    CommandInfo As CommandInfo
+    Config As Config
+    Tokens As Tokens
+End Type
+
+Private this As TExportCommand
+
+Private Sub Class_Initialize()
+    CLI.Lang.SetBlock "/root/ppmCommands/auth"
+
+    Set this.CommandInfo = New CommandInfo
+    this.CommandInfo.Name = "auth"
+    this.CommandInfo.Description = CLI.Lang.GetValue("description")
+    this.CommandInfo.Usage = CLI.Lang.GetValues("usage")
+End Sub
+
+Public Property Set Config(ByVal RHS As Config)
+    Set this.Config = RHS
+End Property
+
+Public Property Set Tokens(ByVal RHS As Tokens)
+    Set this.Tokens = RHS
+End Property
+
+Private Property Get ICommand_CommandInfo() As CommandInfo
+    Set ICommand_CommandInfo = this.CommandInfo
+End Property
+
+Private Sub ICommand_Exec()
+    If Not this.Tokens.IncludeTokenKind(TokenKind.Identifier) Then
+        ppm "auth --help"
+        Exit Sub
+    End If
+
+    Dim EmailToken As SyntaxToken
+    Set EmailToken = this.Tokens.GetFirstTokenKind(TokenKind.Identifier)
+    Dim Email As String
+    Email = EmailToken.Text
+
+    Dim JSONBody As String
+    JSONBody = "{""email"": """ & Email & """}"
+    Dim Body() As Byte
+    Body = Strings.StrConv(JSONBody, VbStrConv.vbFromUnicode)
+
+    Dim Headers As Object
+    Set Headers = NewDictionary()
+    Headers("Content-Type") = "application/json"
+    Headers("Content-Length") = Strings.Len(JSONBody)
+
+    Immediate.WriteLine "Waiting answer from server..."
+
+    Dim Request As HTTP
+    Set Request = New HTTP
+    Dim Response As TResponse
+    Response = Request.PostRequest("http://localhost:8000/auth", Headers, "{""email"": """ & Email & """}")
+
+    If Response.Code = 400 Then
+        Dim Error As Object
+        Set Error = PJSON.Parse(Response.Text)
+        Immediate.WriteLine Error("error")
+        Exit Sub
+    ElseIf Response.Code <> HTTPCodes.CREATED_201 Then
+        Immediate.WriteLine "ERR!"
+        Exit Sub
+    End If
+
+    Dim JSON As Object
+    Set JSON = PJSON.Parse(Response.Text)
+
+    Dim Config As Config
+    Set Config = NewConfig(ConfigScopes.UserScope)
+    Config.File.CreateOrWrite "email", Email
+    Config.File.CreateOrWrite "api_key", JSON("api_key")
+
+    Immediate.WriteLine FString("Your api-key for email '{0}': {1}", Email, JSON("api_key"))
+End Sub

--- a/src/CLI/Commands/Auth/AuthCommand.cls
+++ b/src/CLI/Commands/Auth/AuthCommand.cls
@@ -75,7 +75,7 @@ Private Sub ICommand_Exec()
         Immediate.WriteLine Error("error")
         Exit Sub
     ElseIf Response.Code <> HTTPCodes.CREATED_201 Then
-        Immediate.WriteLine "ERR!"
+        Immediate.WriteLine "internal server error!"
         Exit Sub
     End If
 

--- a/src/CLI/Commands/Auth/AuthCommand.cls
+++ b/src/CLI/Commands/Auth/AuthCommand.cls
@@ -26,6 +26,7 @@ Private Sub Class_Initialize()
     Set this.CommandInfo = New CommandInfo
     this.CommandInfo.Name = "auth"
     this.CommandInfo.Description = CLI.Lang.GetValue("description")
+    this.CommandInfo.Params.Item("registry") = CLI.Lang.GetValue("param", "name=registry")
     this.CommandInfo.Usage = CLI.Lang.GetValues("usage")
 End Sub
 
@@ -48,7 +49,7 @@ Private Sub ICommand_Exec()
     End If
 
     Dim EmailToken As SyntaxToken
-    Set EmailToken = this.Tokens.GetFirstTokenKind(TokenKind.Identifier)
+    Set EmailToken = this.Tokens.PopFirstTokenKind(TokenKind.Identifier)
     Dim Email As String
     Email = EmailToken.Text
 
@@ -66,8 +67,16 @@ Private Sub ICommand_Exec()
 
     Dim Request As HTTP
     Set Request = New HTTP
+    Dim RegistryURL As String
+    RegistryURL = GetFirstValueFrom("registry", this.Tokens, this.Config)
+    If Strings.Len(RegistryURL) = 0 Then
+        RegistryURL = Definitions("registry").Default
+    End If
+    Dim AuthURL As String
+    AuthURL = Utils.ResolveUrl(RegistryURL, "/auth")
+
     Dim Response As TResponse
-    Response = Request.PostRequest("http://localhost:8000/auth", Headers, "{""email"": """ & Email & """}")
+    Response = Request.PostRequest(AuthURL, Headers, "{""email"": """ & Email & """}")
 
     If Response.Code = 400 Then
         Dim Error As Object
@@ -89,3 +98,33 @@ Private Sub ICommand_Exec()
 
     Immediate.WriteLine FString("Your api-key for email '{0}': {1}", Email, JSON("api_key"))
 End Sub
+
+Public Function GetFirstValueFrom(ByVal DefName As String, ByRef Tokens As Tokens, ByRef Config As Config) As Variant
+    If Not Definitions.Items().Exists(DefName) Then
+        Err.Raise 9, "Utils", "Can't find definition: " & DefName
+    End If
+
+    Dim Def As Definition
+    Set Def = Definitions(DefName)
+
+    If Tokens.IncludeDefinition(Def) Then
+        Dim Token As SyntaxToken
+        Set Token = Tokens.PopTokenByDefinition(Def)
+        If IsFalse(Token) Then
+            GetFirstValueFrom = True
+        Else
+            GetFirstValueFrom = ConvertToType(Token.Text, Def.DataType)
+        End If
+    Else
+        Dim Value As Variant
+        Value = GetFirstTrue( _
+            Config.GetValue(DefName), _
+            Def.Default _
+        )
+        If Not Information.IsNull(Value) Then
+            GetFirstValueFrom = ConvertToType(Value, Def.DataType)
+        Else
+            GetFirstValueFrom = ConvertToType(Def.Default, Def.DataType)
+        End If
+    End If
+End Function

--- a/src/CLI/Commands/Auth/AuthCommandCstr.bas
+++ b/src/CLI/Commands/Auth/AuthCommandCstr.bas
@@ -1,0 +1,9 @@
+Attribute VB_Name = "AuthCommandCstr"
+'@Folder "PearPMProject.src.CLI.Commands.Auth"
+Option Explicit
+
+Public Function NewAuthCommand(ByRef Config As Config, ByRef Tokens As Tokens) As AuthCommand
+    Set NewAuthCommand = New AuthCommand
+    Set NewAuthCommand.Config = Config
+    Set NewAuthCommand.Tokens = Tokens
+End Function

--- a/src/CLI/Commands/Class/ClassCommand.cls
+++ b/src/CLI/Commands/Class/ClassCommand.cls
@@ -54,7 +54,7 @@ Private Sub ICommand_Exec()
         Exit Sub
     End If
 
-    this.FullPath = Me.GetFullPath(this.Tokens.GetFirstTokenKind(TokenKind.Identifier).Text)
+    this.FullPath = Me.GetFullPath(this.Tokens.PopFirstTokenKind(TokenKind.Identifier).Text)
     this.Parts = Strings.Split(this.FullPath, ".")
     this.Name = this.Parts(UBound(this.Parts))
     this.CstrName = this.Name & "Cstr"
@@ -71,7 +71,7 @@ Private Sub ICommand_Exec()
     End If
 
     Dim SubCommand As SyntaxToken
-    Set SubCommand = this.Tokens.GetFirstTokenKind(TokenKind.SubCommand)
+    Set SubCommand = this.Tokens.PopFirstTokenKind(TokenKind.SubCommand)
     Dim SubCommandName As String
     If IsTrue(SubCommand) Then
         SubCommandName = SubCommand.Text

--- a/src/CLI/Commands/Config/ConfigCommand.cls
+++ b/src/CLI/Commands/Config/ConfigCommand.cls
@@ -47,7 +47,7 @@ Private Sub ICommand_Exec()
     Dim Config As Config: Set Config = GetConfig()
 
     Dim SubCommand As SyntaxToken
-    Set SubCommand = this.Tokens.GetFirstTokenKind(TokenKind.SubCommand)
+    Set SubCommand = this.Tokens.PopFirstTokenKind(TokenKind.SubCommand)
 
     Dim SubCommandName As String
     If IsTrue(SubCommand) Then
@@ -92,7 +92,7 @@ Public Function GetConfig() As Config
 
     Dim Location As String
     If this.Tokens.IncludeDefinition(LocationDef) Then
-        Location = this.Tokens.GetTokenByDefinition(LocationDef).Text
+        Location = this.Tokens.PopTokenByDefinition(LocationDef).Text
     Else
         Set GetConfig = NewConfig(ConfigScopes.ProjectScope)
         Exit Function

--- a/src/CLI/Commands/Help/HelpCommand.cls
+++ b/src/CLI/Commands/Help/HelpCommand.cls
@@ -76,7 +76,7 @@ End Sub
 Public Function GetCommandName() As String
     Dim Commands As Variant: Commands = this.Tokens.GetTokensKind(TokenKind.Command)
     If UBound(Commands) = -1 Then
-        GetCommandName = this.Tokens.GetFirstTokenKind(TokenKind.Identifier).Text
+        GetCommandName = this.Tokens.PopFirstTokenKind(TokenKind.Identifier).Text
         Exit Function
     End If
 

--- a/src/CLI/Commands/Init/InitCommand.cls
+++ b/src/CLI/Commands/Init/InitCommand.cls
@@ -58,7 +58,7 @@ Private Sub ICommand_Exec()
     HaveProjectName = this.Tokens.IncludeTokenKind(TokenKind.Identifier)
     Dim InitialName As String
     If HaveProjectName Then
-        InitialName = this.Tokens.GetFirstTokenKind(TokenKind.Identifier).Text
+        InitialName = this.Tokens.PopFirstTokenKind(TokenKind.Identifier).Text
     End If
 
     If IsTrue(Pack) And Not AfterDialog Then
@@ -104,7 +104,7 @@ Private Sub ICommand_Exec()
     End If
 End Sub
 
-Public Sub CreatePackComponent()
+Public Function CreatePackComponent() As Object
   #If DEV Then
     Dim PackComponent As VBComponent
   #Else
@@ -132,7 +132,9 @@ Public Sub CreatePackComponent()
         .AddFromString Utils.CommentString(JB.ToString())
         .InsertLines 1, PStrings.FString("'@Folder(""{0}"")", SelectedProject.Name)
     End With
-End Sub
+
+    Set CreatePackComponent = PackComponent
+End Function
 
 Public Function GetReferences() As Object
     Dim References As Object

--- a/src/CLI/Commands/Install/InstallCommand.cls
+++ b/src/CLI/Commands/Install/InstallCommand.cls
@@ -242,11 +242,7 @@ End Function
 
 Public Function GetLibPackFromServer(ByVal LibName As String, ByVal Version As String) As Pack
     Dim URL As String
-    If Strings.Right(this.Registry, 1) <> "/" Then
-        URL = this.Registry & PStrings.FString("/{0}/{1}", LibName, Version)
-    Else
-        URL = this.Registry & PStrings.FString("{0}/{1}", LibName, Version)
-    End If
+    URL = Utils.ResolveUrl(this.Registry, PStrings.FString("/{0}/{1}", LibName, Version))
 
     Dim HTTP As HTTP: Set HTTP = New HTTP
     Dim Response As TResponse
@@ -254,8 +250,13 @@ Public Function GetLibPackFromServer(ByVal LibName As String, ByVal Version As S
     Response = HTTP.GetRequest(URL)
     On Error GoTo 0
     If Response.Code <> HTTPCodes.OK_200 Then
-        Immediate.WriteLine CLI.Lang.GetValue("messages/somethingWentWrong")
-        Immediate.WriteLine Response.Text
+        Dim JSONResponse As Object
+        Set JSONResponse = PJSON.Parse(Response.Text)
+        If Err.Number = 0 Then
+            Immediate.WriteLine "ERR:", JSONResponse("error")
+        Else
+            Immediate.WriteLine CLI.Lang.GetValue("messages/somethingWentWrong")
+        End If
         End
     End If
 
@@ -310,11 +311,6 @@ End Function
 #Else
   Public Function DownloadLibs(ByRef Libs As Object) As Variant
 #End If
-    Dim Registry As String
-    If Strings.Right(this.Registry, 1) <> "/" Then
-        Registry = this.Registry & "/"
-    End If
-
     Dim HTTP As HTTP: Set HTTP = New HTTP
     Dim Converter As BinaryConverter: Set Converter = New BinaryConverter
     Dim Paths As Collection: Set Paths = New Collection
@@ -326,7 +322,7 @@ End Function
     For Each Name In Libs
         Dim Version As String: Version = Libs(Name)
         Dim URL As String
-        URL = PStrings.FString("{0}{1}/{2}", Registry, Name, Version)
+        URL = Utils.ResolveUrl(this.Registry, PStrings.FString("/{0}/{1}", Name, Version))
         Dim Response As TResponse
         Response = HTTP.GetRequest(URL)
         If Response.Code <> HTTPCodes.OK_200 Then

--- a/src/CLI/Commands/Module/ModuleCommand.cls
+++ b/src/CLI/Commands/Module/ModuleCommand.cls
@@ -52,7 +52,7 @@ Private Sub ICommand_Exec()
         Exit Sub
     End If
 
-    this.FullPath = Me.GetFullPath(this.Tokens.GetFirstTokenKind(TokenKind.Identifier).Text)
+    this.FullPath = Me.GetFullPath(this.Tokens.PopFirstTokenKind(TokenKind.Identifier).Text)
     this.Parts = Strings.Split(this.FullPath, ".")
     this.Name = this.Parts(UBound(this.Parts))
 
@@ -68,7 +68,7 @@ Private Sub ICommand_Exec()
     End If
 
     Dim SubCommand As SyntaxToken
-    Set SubCommand = this.Tokens.GetFirstTokenKind(TokenKind.SubCommand)
+    Set SubCommand = this.Tokens.PopFirstTokenKind(TokenKind.SubCommand)
     Dim SubCommandName As String
     If IsTrue(SubCommand) Then
         SubCommandName = SubCommand.Text

--- a/src/CLI/Commands/Module/ModuleCommandCstr.bas
+++ b/src/CLI/Commands/Module/ModuleCommandCstr.bas
@@ -1,5 +1,5 @@
 Attribute VB_Name = "ModuleCommandCstr"
-'@Folder("PearPMProject.src.CLI.Commands.Module")
+'@Folder "PearPMProject.src.CLI.Commands.Module"
 Option Explicit
 
 Public Function NewModuleCommand(ByRef Config As Config, ByRef Tokens As Tokens) As ModuleCommand

--- a/src/CLI/Commands/Publish/PublishCommand.cls
+++ b/src/CLI/Commands/Publish/PublishCommand.cls
@@ -44,6 +44,15 @@ Private Property Get ICommand_CommandInfo() As CommandInfo
 End Property
 
 Private Sub ICommand_Exec()
+    Dim Config As Config
+    Set Config = NewConfig(ConfigScopes.UserScope)
+
+    Dim Credentials As Object
+    Set Credentials = NewDictionary()
+
+    Credentials("email") = Config.GetValue("email")
+    Credentials("api_key") = Config.GetValue("api_key")
+
     If Not SelectedProject.IsComponentExists("package") Then
         Immediate.WriteLine PStrings.FString(CLI.Lang.GetValue("messages/packageModuleNotFound"))
         End
@@ -89,7 +98,7 @@ Private Sub ICommand_Exec()
         Success = PublishOnLocal(Registry, ZipPath, Pack)
     Else
         Dim Response As TResponse
-        Response = PublishOnServer(Registry, ZipPath, Pack)
+        Response = PublishOnServer(Registry, ZipPath, Pack, Credentials)
         Success = Response.Code = HTTPCodes.OK_200 Or _
                   Response.Code = HTTPCodes.CREATED_201
     End If
@@ -177,7 +186,7 @@ Public Function PublishOnLocal(ByVal Registry As String, ByVal ZipPath As String
     PublishOnLocal = True
 End Function
 
-Public Function PublishOnServer(ByVal Registry As String, ByVal ZipPath As String, ByRef Pack As Pack) As TResponse
+Public Function PublishOnServer(ByVal Registry As String, ByVal ZipPath As String, ByRef Pack As Pack, ByRef Credentials As Object) As TResponse
     Dim FormData As FormData: Set FormData = New FormData
 
   #If DEV Then
@@ -199,6 +208,8 @@ Public Function PublishOnServer(ByVal Registry As String, ByVal ZipPath As Strin
     Dim Headers As Object: Set Headers = NewDictionary()
   #End If
     Headers("Content-Type") = "multipart/form-data; boundary=" & FormData.Boundary
+    Headers("email") = Credentials("email")
+    Headers("api-key") = Credentials("api_key")
 
     Dim HTTP As HTTP: Set HTTP = New HTTP
     PublishOnServer = HTTP.PostRequest( _

--- a/src/CLI/Commands/Publish/PublishCommand.cls
+++ b/src/CLI/Commands/Publish/PublishCommand.cls
@@ -87,6 +87,7 @@ Private Sub ICommand_Exec()
     ToLocal = GetFirstValueFrom("local", this.Tokens, this.Config)
     Dim Registry As String
     Registry = GetFirstValueFrom("registry", this.Tokens, this.Config)
+    Registry = Utils.ResolveUrl(Registry)
     If ToLocal Then
         If Not NewFileSystemObject().FolderExists(Registry) Then
             PFileSystem.CreateFolder Registry, Recoursive:=True

--- a/src/CLI/Commands/Ref/RefCommand.cls
+++ b/src/CLI/Commands/Ref/RefCommand.cls
@@ -52,7 +52,7 @@ End Property
 
 Private Sub ICommand_Exec()
     Dim SubCommand As SyntaxToken
-    Set SubCommand = this.Tokens.GetFirstTokenKind(TokenKind.SubCommand)
+    Set SubCommand = this.Tokens.PopFirstTokenKind(TokenKind.SubCommand)
     Dim SubCommandName As String
     If IsTrue(SubCommand) Then
         SubCommandName = SubCommand.Text
@@ -63,7 +63,7 @@ Private Sub ICommand_Exec()
     End If
 
     If this.Tokens.IncludeTokenKind(TokenKind.Identifier) Then
-        this.Name = this.Tokens.GetFirstTokenKind(TokenKind.Identifier).Text
+        this.Name = this.Tokens.PopFirstTokenKind(TokenKind.Identifier).Text
         If PStrings.StartsWith(this.Name, "{") Then
             this.NameType = NameTypes.TypeGUID
         ElseIf NewFileSystemObject().FileExists(this.Name) Then

--- a/src/CLI/Commands/Search/SearchCommand.cls
+++ b/src/CLI/Commands/Search/SearchCommand.cls
@@ -7,7 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
-'@Folder("PearPMProject.src.CLI.Commands.Search")
+'@Folder "PearPMProject.src.CLI.Commands.Search"
 Option Explicit
 
 Implements ICommand

--- a/src/CLI/Commands/Search/SearchCommand.cls
+++ b/src/CLI/Commands/Search/SearchCommand.cls
@@ -44,8 +44,14 @@ Private Property Get ICommand_CommandInfo() As CommandInfo
 End Property
 
 Private Sub ICommand_Exec()
+    Dim Registry As String
+    Registry = GetFirstValueFrom("registry", this.Tokens, this.Config)
+
+    Dim IsLocal As Boolean
+    IsLocal = GetFirstValueFrom("local", this.Tokens, this.Config)
+
     Dim PackageToken As SyntaxToken
-    Set PackageToken = this.Tokens.GetFirstTokenKind(TokenKind.Identifier)
+    Set PackageToken = this.Tokens.PopFirstTokenKind(TokenKind.Identifier)
     If IsFalse(PackageToken) Then
         Immediate.WriteLine CLI.Lang.GetValue("messages/nameMissing")
         Exit Sub
@@ -54,10 +60,7 @@ Private Sub ICommand_Exec()
     Dim PackageName As String
     PackageName = PackageToken.Text
 
-    Dim Registry As String
-    Registry = GetFirstValueFrom("registry", this.Tokens, this.Config)
-
-    If GetFirstValueFrom("local", this.Tokens, this.Config) Then
+    If IsLocal Then
         LookupLocal Registry, PackageName
     Else
         LookupOnServer Registry, PackageName
@@ -66,11 +69,7 @@ End Sub
 
 Public Sub LookupOnServer(ByVal Registry As String, ByVal PackageName As String)
     Dim URL As String
-    If Strings.Right(Registry, 1) <> "/" Then
-        URL = Registry & PStrings.FString("/search/{0}", PackageName)
-    Else
-        URL = Registry & PStrings.FString("search/{0}", PackageName)
-    End If
+    URL = Utils.ResolveUrl(Registry, PStrings.FString("/-/search/{0}", PackageName))
 
     Dim HTTP As HTTP: Set HTTP = New HTTP
     Dim Response As TResponse

--- a/src/CLI/Commands/Version/VersionCommand.cls
+++ b/src/CLI/Commands/Version/VersionCommand.cls
@@ -7,7 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
-'@Folder("PearPMProject.src.CLI.Commands.Version")
+'@Folder "PearPMProject.src.CLI.Commands.Version"
 
 Implements ICommand
 

--- a/src/CLI/Commands/Version/VersionCommand.cls
+++ b/src/CLI/Commands/Version/VersionCommand.cls
@@ -45,13 +45,13 @@ Private Sub ICommand_Exec()
     Dim NewVers As String
 
     Dim SubCommand As SyntaxToken
-    Set SubCommand = this.Tokens.GetFirstTokenKind(TokenKind.SubCommand)
+    Set SubCommand = this.Tokens.PopFirstTokenKind(TokenKind.SubCommand)
     Dim SubCommandName As String
     If IsTrue(SubCommand) Then
         SubCommandName = SubCommand.Text
     Else
         Dim NewVersToken As SyntaxToken
-        Set NewVersToken = this.Tokens.GetFirstTokenKind(TokenKind.Identifier)
+        Set NewVersToken = this.Tokens.PopFirstTokenKind(TokenKind.Identifier)
         If IsFalse(NewVersToken) Then
             Immediate.WriteLine PStrings.FString("v{0}", Pack.Version)
             Exit Sub

--- a/src/CLI/Commands/Version/VersionCommandCstr.bas
+++ b/src/CLI/Commands/Version/VersionCommandCstr.bas
@@ -1,5 +1,5 @@
 Attribute VB_Name = "VersionCommandCstr"
-'@Folder("PearPMProject.src.CLI.Commands.Version")
+'@Folder "PearPMProject.src.CLI.Commands.Version"
 Option Explicit
 
 Public Function NewVersionCommand(ByRef Config As Config, ByRef Tokens As Tokens) As VersionCommand

--- a/src/CLI/Lexer/Lexer.cls
+++ b/src/CLI/Lexer/Lexer.cls
@@ -52,7 +52,7 @@ Public Function Lex() As Tokens
         Dim Length As Long: Length = this.Position - this.Start
         Dim Text As String
         Text = Strings.Mid(this.Text, this.Start, Length)
-        this.Tokens.Add NewSyntaxToken(this.Kind, Text)
+        this.Tokens.Push NewSyntaxToken(this.Kind, Text)
         If Current = """" Or Current = "'" Then this.Position = this.Position + 1
 Continue:
     Loop

--- a/src/CLI/Lexer/Tokens.cls
+++ b/src/CLI/Lexer/Tokens.cls
@@ -39,15 +39,19 @@ Attribute NewEnum.VB_UserMemId = -4
     Set NewEnum = this.CurrentEnum
 End Property
 
-Public Sub Add(ByRef Token As SyntaxToken)
+Public Sub Push(ByRef Token As SyntaxToken)
     this.Tokens.Add Token
 End Sub
 
-Public Function GetToken(ByVal Text As String, ByVal Kind As TokenKind) As SyntaxToken
+Public Function PopToken(ByVal Text As String, ByVal Kind As TokenKind) As SyntaxToken
     Dim Token As SyntaxToken
+    Dim i As Long
+    i = 0
     For Each Token In this.Tokens
+        i = i + 1
         If Token.Kind = Kind And IsEqual(Token.Text, Text) Then
-            Set GetToken = Token
+            Set PopToken = Token
+            this.Tokens.Remove i
             Exit Function
         End If
     Next
@@ -66,18 +70,23 @@ Public Function GetTokenIndex(ByVal Text As String, ByVal Kind As TokenKind) As 
     GetTokenIndex = -1
 End Function
 
-Public Function GetNextTokenAfter(ByVal Text As String, ByVal Kind As TokenKind) As SyntaxToken
+Public Function PopNextTokenAfter(ByVal Text As String, ByVal Kind As TokenKind) As SyntaxToken
     Dim i As Long: i = Me.GetTokenIndex(Text, Kind)
     If i = -1 Then Exit Function
     If i + 1 > this.Tokens.Count Then Exit Function
-    Set GetNextTokenAfter = this.Tokens(i + 1)
+    Set PopNextTokenAfter = this.Tokens(i + 1)
+    this.Tokens.Remove i + 1
 End Function
 
-Public Function GetFirstTokenKind(ByVal Kind As TokenKind) As SyntaxToken
+Public Function PopFirstTokenKind(ByVal Kind As TokenKind) As SyntaxToken
     Dim Token As SyntaxToken
+    Dim i As Long
+    i = 0
     For Each Token In this.Tokens
+        i = i + 1
         If Token.Kind = Kind Then
-            Set GetFirstTokenKind = Token
+            Set PopFirstTokenKind = Token
+            this.Tokens.Remove i
             Exit Function
         End If
     Next
@@ -101,11 +110,11 @@ Public Function IncludeDefinition(ByRef Definition As Definition) As Boolean
                         Me.IncludeToken(Definition.Short, TokenKind.ShortOptionItem)
 End Function
 
-Public Function GetTokenByDefinition(ByRef Definition As Definition) As SyntaxToken
+Public Function PopTokenByDefinition(ByRef Definition As Definition) As SyntaxToken
     If Me.IncludeToken(Definition.Key, TokenKind.OptionItem) Then
-        Set GetTokenByDefinition = Me.GetNextTokenAfter(Definition.Key, TokenKind.OptionItem)
+        Set PopTokenByDefinition = Me.PopNextTokenAfter(Definition.Key, TokenKind.OptionItem)
     ElseIf Me.IncludeToken(Definition.Short, TokenKind.ShortOptionItem) Then
-        Set GetTokenByDefinition = Me.GetNextTokenAfter(Definition.Short, TokenKind.ShortOptionItem)
+        Set PopTokenByDefinition = Me.PopNextTokenAfter(Definition.Short, TokenKind.ShortOptionItem)
     End If
 End Function
 

--- a/src/Config/Config.cls
+++ b/src/Config/Config.cls
@@ -60,19 +60,21 @@ Public Sub SetScope(ByVal Scope As ConfigScopes)
 End Sub
 
 Public Function GetValue(ByVal Key As String) As Variant
-    If Not Definitions.Items().Exists(Key) Then
-        Err.Raise 9, Information.TypeName(Me), "Can't find definition: " & Key
-    End If
-
-    Dim Definition As Definition
-    Set Definition = Definitions(Key)
-
   #If DEV Then
     Dim Data As Dictionary
   #Else
     Dim Data As Object
   #End If
     Set Data = this.File.Read()
+
+    If Not Definitions.Items().Exists(Key) Then
+        GetValue = Data(Key)
+        Exit Function
+    End If
+
+    Dim Definition As Definition
+    Set Definition = Definitions(Key)
+
     If Data.Exists(Definition.Key) Then
         GetValue = Utils.ConvertToType(Data(Definition.Key), Definition.DataType)
         Exit Function

--- a/src/Config/ConfigEnum.bas
+++ b/src/Config/ConfigEnum.bas
@@ -1,5 +1,5 @@
 Attribute VB_Name = "ConfigEnum"
-'@Folder("PearPMProject.src.Config")
+'@Folder "PearPMProject.src.Config"
 Option Explicit
 
 Public Enum ConfigScopes

--- a/src/Config/Definitions.cls
+++ b/src/Config/Definitions.cls
@@ -79,25 +79,6 @@ Attribute Items.VB_UserMemId = 0
     )
     Set Buffer(Definition.Key) = Definition
 
-    With NewFileSystemObject()
-        Dim PpmFolder As String
-        PpmFolder = .BuildPath(Interaction.Environ("APPDATA"), "ppm")
-        Dim RegistryPath As String
-        RegistryPath = .BuildPath(PpmFolder, "registry")
-        If Not .FolderExists(PpmFolder) Then
-            .CreateFolder PpmFolder
-        End If
-        If Not .FolderExists(RegistryPath) Then
-            .CreateFolder RegistryPath
-        End If
-    End With
-
-    Set Definition = NewDefinition( _
-        Key:="registry", _
-        Default:=RegistryPath _
-    )
-    Set Buffer(Definition.Key) = Definition
-
     Set Definition = NewDefinition( _
         Key:="language", _
         Default:="eng" _
@@ -133,6 +114,12 @@ Attribute Items.VB_UserMemId = 0
         Key:="path", _
         Short:="p", _
         Default:="" _
+    )
+    Set Buffer(Definition.Key) = Definition
+
+    Set Definition = NewDefinition( _
+        Key:="registry", _
+        Default:="https://registry.ppmvba.com/" _
     )
     Set Buffer(Definition.Key) = Definition
 

--- a/src/Config/Definitions.cls
+++ b/src/Config/Definitions.cls
@@ -14,7 +14,6 @@ Option Explicit
 #If DEV Then
   '@DefaultMember
   Public Property Get Items() As Dictionary
-Attribute Items.VB_UserMemId = 0
 #Else
   '@DefaultMember
   Public Property Get Items() As Object

--- a/src/Utils/AddinInstaller.bas
+++ b/src/Utils/AddinInstaller.bas
@@ -1,5 +1,5 @@
 Attribute VB_Name = "AddinInstaller"
-'@Folder("PearPMProject.src.Utils")
+'@Folder "PearPMProject.src.Utils"
 Option Explicit
 
 Public Sub SwitchAddin()

--- a/src/Utils/Constants.bas
+++ b/src/Utils/Constants.bas
@@ -1,3 +1,0 @@
-Attribute VB_Name = "Constants"
-'@Folder "PearPMProject.src.Utils"
-Option Explicit

--- a/src/Utils/Utils.bas
+++ b/src/Utils/Utils.bas
@@ -254,7 +254,7 @@ Public Function GetFirstValueFrom(ByVal DefName As String, ByRef Tokens As Token
 
     If Tokens.IncludeDefinition(Def) Then
         Dim Token As SyntaxToken
-        Set Token = Tokens.GetTokenByDefinition(Def)
+        Set Token = Tokens.PopTokenByDefinition(Def)
         If IsFalse(Token) Then
             GetFirstValueFrom = True
         Else
@@ -272,4 +272,29 @@ Public Function GetFirstValueFrom(ByVal DefName As String, ByRef Tokens As Token
             GetFirstValueFrom = ConvertToType(Def.Default, Def.DataType)
         End If
     End If
+End Function
+
+Public Function ResolveUrl(ByVal URL As String, Optional ByVal EndPoint As String) As String
+    If Not PStrings.StartsWith(URL, "http") Then
+        URL = "http://" & URL
+    End If
+
+    If Not PStrings.EndsWith(URL, "/") Then
+        URL = URL & "/"
+    End If
+
+    If Strings.Len(EndPoint) = 0 Then
+        ResolveUrl = URL
+        Exit Function
+    End If
+
+    If PStrings.StartsWith(EndPoint, "/") Then
+        EndPoint = Strings.Right(EndPoint, Strings.Len(EndPoint) - 1)
+    End If
+
+    If PStrings.EndsWith(EndPoint, "/") Then
+        EndPoint = Strings.Left(EndPoint, Strings.Len(EndPoint) - 1)
+    End If
+
+    ResolveUrl = URL & EndPoint
 End Function


### PR DESCRIPTION
**Features:**
`ppm "auth <email> --registry URL"`

**Fixes:**
When trying to install and publish to the remote registry, various
errors were popping up:
- invalid url when the url was passed without the leading http
- unknown library when the path to the remote registry was passed before
the library name: `ppm “--registry URL libname”`

In the wake of these bugs, the publish, install, and search commands were fixed.
The fix resulted in changing the Get methods in Tokens to Pop so that
the received token is removed from the collection.