### PR TITLE
Add `generate` subcommand to `config` command

### DIFF
--- a/.ppmrc
+++ b/.ppmrc
@@ -1,0 +1,7 @@
+create-constructor=True
+encoding=UTF-8
+language=eng
+local=False
+no-clear=False
+registry=https://registry.ppmvba.com/
+save-struct=True

--- a/languages/eng.xml
+++ b/languages/eng.xml
@@ -116,6 +116,12 @@
                 <deleted>
                     key '{0}' deleted
                 </deleted>
+                <needSaveProject>
+                    Need save project before generate config file.
+                </needSaveProject>
+                <fileGenerated>
+                    Generated config file: {0}
+                </fileGenerated>
             </messages>
         </config>
         <export>

--- a/languages/rus.xml
+++ b/languages/rus.xml
@@ -116,6 +116,12 @@
                 <deleted>
                     ключ '{0}' удален
                 </deleted>
+                <needSaveProject>
+                    Необходимо сохранить проект перед созданием файла конфигурации.
+                </needSaveProject>
+                <fileGenerated>
+                    Создан файл конфигурации: {0}
+                </fileGenerated>
             </messages>
         </config>
         <export>

--- a/src/CLI/CLI.bas
+++ b/src/CLI/CLI.bas
@@ -35,6 +35,7 @@ Public Property Get SubCommands() As Variant
     SubCommands = Array( _
         "delete", _
         "edit", _
+        "generate", _
         "get", _
         "list", _
         "major", _

--- a/src/CLI/Commands/Config/ConfigCommand.cls
+++ b/src/CLI/Commands/Config/ConfigCommand.cls
@@ -55,6 +55,19 @@ Private Sub ICommand_Exec()
         ppm "config --help"
     End If
 
+    If SubCommandName = "generate" Then
+        If Not SelectedProject.IsSaved Then
+            CLI.Lang.GetValue ("messages/needSaveProject")
+            Exit Sub
+        End If
+
+        GenerateDeafultConfig
+        Immediate.WriteLine PStrings.FString( _
+            CLI.Lang.GetValue("messages/fileGenerated"), PFileSystem.BuildPath(SelectedProject.Folder, ".ppmrc") _
+        )
+        Exit Sub
+    End If
+
     If CLI.Aliases.Exists(SubCommandName) Then
         SubCommandName = CLI.Aliases(SubCommandName)
     End If
@@ -76,6 +89,39 @@ Private Sub ICommand_Exec()
             ConfigList Config
 
     End Select
+End Sub
+
+Public Sub GenerateDeafultConfig()
+    Dim Config As Config
+    Set Config = NewConfig(ConfigScopes.ProjectScope)
+
+    Dim SkipableKeys As Variant
+    SkipableKeys = Array( _
+        "author-name", _
+        "author-url", _
+        "dev-dep", _
+        "help", _
+        "location", _
+        "name", _
+        "path", _
+        "version", _
+        "yes" _
+    )
+
+    Dim Definition As Variant
+    For Each Definition In Definitions.Items.Items
+        If PArray.IncludesAny(SkipableKeys, Definition.Key) Then GoTo Continue
+        If PStrings.StartsWith(Definition.Key, "_") Then GoTo Continue
+
+        Dim Value As String
+        If Information.IsMissing(Definition.Default) Then
+            Value = ""
+        Else
+            Value = Conversion.CStr(Definition.Default)
+        End If
+        Config.File.CreateOrWrite Definition.Key, Value
+Continue:
+    Next
 End Sub
 
 Public Function GetConfig() As Config

--- a/src/CLI/Lexer/Lexer.cls
+++ b/src/CLI/Lexer/Lexer.cls
@@ -98,7 +98,6 @@ End Sub
 
 Private Sub ReadIdentifier()
     Do While Not PStrings.IsWhiteSpace(Current) And _
-             Not Current = "-" And _
              Not Current = "="
         this.Position = this.Position + 1
         If Information.IsNull(Current) Then Exit Do

--- a/src/Config/Config.cls
+++ b/src/Config/Config.cls
@@ -37,7 +37,7 @@ Public Sub SetScope(ByVal Scope As ConfigScopes)
     Dim Folder As String
     Select Case Scope
         Case ConfigScopes.ProjectScope
-            Folder = FSO.BuildPath(SelectedProject.Folder, ".ppm")
+            Folder = SelectedProject.Folder
         Case ConfigScopes.UserScope
             Folder = FSO.BuildPath(Interaction.Environ("APPDATA"), "ppm")
         Case ConfigScopes.GlobalScode


### PR DESCRIPTION
It generates project config with default definitions,
excluding some special definitions.